### PR TITLE
fix some highlight string colors

### DIFF
--- a/redbaron.py
+++ b/redbaron.py
@@ -795,7 +795,7 @@ class HelpLexer(RegexLexer):
     tokens = {
         'root': [
             (r"#.*$", Comment),
-            (r"'[^']*'", String),
+            (r"('([^\\']|\\.)*'|\"([^\\\"]|\\.)*\")", String),
             (r"(None|False|True)", String),
             (r'(\*)( \w+Node)', bygroups(Operator, Keyword)),
             (r'\w+Node', Name.Function),


### PR DESCRIPTION
redbaron has some trouble highlighting properly strings containing quotes (')

Mainly visible with .help() functions, not sure default repr is affected.

Example with a foo.py file, trying to have most common quotable features:

```
def foo():
  a = 'Simple quoted \' string'
  b = "Double quoted \" string"
  c = '''Multi-simple quoted ' string'''
  d = """Multi-double quoted " string"""
def bar():
  e = 'Simple quoted \' string and some " for fun'
  f = "Double quoted \" string and some ' for fun"
  g = '''Multi-simple quoted ' string and some " for fun'''
  h = """Multi-double quoted " string and some ' for fun"""
```

And the code I used to show the highlights:

```
from redbaron import RedBaron
red = RedBaron(open('foo.py').read())

red[0].findAll('string').help()
red[1].findAll('string').help()
```
