### PR TITLE
Return inserted value with "insert"

### DIFF
--- a/redbaron.py
+++ b/redbaron.py
@@ -1057,10 +1057,10 @@ class Node(GenericNodesUtils):
         self.get_indentation_node().indent = self.get_indentation_node().indent[:-len(number_of_spaces * " ")]
 
     def insert_before(self, value, offset=0):
-        self.parent.insert(self.index_on_parent - offset, value)
+        return self.parent.insert(self.index_on_parent - offset, value)
 
     def insert_after(self, value, offset=0):
-        self.parent.insert(self.index_on_parent + 1 + offset, value)
+        return self.parent.insert(self.index_on_parent + 1 + offset, value)
 
 
 class CodeBlockNode(Node):
@@ -1296,9 +1296,10 @@ class ProxyList(object):
         value = self._convert_input_to_node_object(value, parent=self.node_list, on_attribute=self.on_attribute)
         self.data.insert(index, value)
         self._diff_augmented_list()
+        return value
 
     def append(self, value):
-        self.insert(len(self), value)
+        return self.insert(len(self), value)
 
     def extend(self, values):
         self.data.extend(self._convert_input_to_node_object_list(values, parent=self.node_list, on_attribute=self.on_attribute))


### PR DESCRIPTION
Hi,
I suggest that insert, insert_after, insert_before and append return the newly inserted value. This is a very common behavior for this kind of functions. Further it is really helpful when one wants to perform actions on a node after it is inserted somewhere.
Thus I am not sure this is the right way to implement it…
