### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,7 +27,7 @@ will be for other releases, the workload is already big enough.
 
 - BIG improvement on the proxy list merging algorithm, it is not perfect yet (comments aren't handled yet) but it's really a big move forward
 - possible retrocompatibility breaking change: from now on the node.find("name") to node.name shortcut ONLY works with possible nodes identifiers. For example node.i_dont_exist_as_an_identifier will raise AttributeError
-- new helper method .to_python that wrap ast.literal_eval on compatibile nodes https://redbaron.readthedocs.org/en/latest/other.html#to-python
+- new helper method .to_python that wrap ast.literal_eval on compatibile nodes https://redbaron.readthedocs.io/en/latest/other.html#to-python
 - breaking: IntNode no longer return an int on .value but a .string instead, use .to_python to have an evaluated version
 - fix node.decrease_indentation (that was simply not working)
 - fix code_block_node.value was broken on node with no parent
@@ -38,11 +38,11 @@ will be for other releases, the workload is already big enough.
 - add getitem() method with same api on NodeList and ProxyList
 - fix: inconsistencies when inserting lines around code blocks
 - inserting a blank lines inserts effectively a \n in a LineProxyList
-- new helper methods: .next_recursive and .previous_recursive https://redbaron.readthedocs.org/en/latest/other.html
+- new helper methods: .next_recursive and .previous_recursive https://redbaron.readthedocs.io/en/latest/other.html
 - fix: doc is tested in CI now, it shouldn't break anymore
 - more rendering test for python3, it shouldn't break anymore
 - pygments is now an optional dependancy, "pip install redbaron" won't install it, "pip install redbaron[pygments"] will
-- new node.next_intuitive and node.previous_intuitive methods for situations where .next/previous doesn't behave the way the user expect it http://redbaron.readthedocs.org/en/latest/other.html#next-intuitive-previous-intuitive
+- new node.next_intuitive and node.previous_intuitive methods for situations where .next/previous doesn't behave the way the user expect it https://redbaron.readthedocs.io/en/latest/other.html#next-intuitive-previous-intuitive
 
 0.5.1 (2015-03-11)
 ------------------
@@ -59,10 +59,10 @@ will be for other releases, the workload is already big enough.
   https://cloud.githubusercontent.com/assets/41827/5731132/65ff4c92-9b80-11e4-977c-0faebbf63415.png
 - fix: RedBaron repr was crashing in bpython and in ipython notebook. The new
   behavior should be way more stable and never crash.
-- new helpers .names, .modules, .full_path_modules for from_import node https://redbaron.readthedocs.org/en/latest/other.html#index-on-parent-raw
+- new helpers .names, .modules, .full_path_modules for from_import node https://redbaron.readthedocs.io/en/latest/other.html#index-on-parent-raw
 - add a node.index_on_parent_raw and make node.index_on_parent works has it
-  should be intuitivly according to the proxy list api https://redbaron.readthedocs.org/en/latest/other.html#index-on-parent-raw
-- new helper methods: .insert_before and .insert_after https://redbaron.readthedocs.org/en/latest/other.html#insert-before-insert-after
+  should be intuitivly according to the proxy list api https://redbaron.readthedocs.io/en/latest/other.html#index-on-parent-raw
+- new helper methods: .insert_before and .insert_after https://redbaron.readthedocs.io/en/latest/other.html#insert-before-insert-after
 - fix: some white space bugs in the merging algorithm of line proxy
 - fix: on_attribute and parent were correctly set on newly added elements to
   the root node
@@ -86,21 +86,21 @@ will be for other releases, the workload is already big enough.
 
 - for EVERY NODES in RedBaron, the automagic behavior when passing a string to
   modify an attribute has been done, this is HUGE improvement
-  https://redbaron.readthedocs.org/en/latest/modifying.html#full-documentations
+  https://redbaron.readthedocs.io/en/latest/modifying.html#full-documentations
 - it's now possible to use regex, globs, list/tuple and lambda (callable) in .find and
-  .find_all, see https://redbaron.readthedocs.org/en/latest/querying.html#advanced-querying
+  .find_all, see https://redbaron.readthedocs.io/en/latest/querying.html#advanced-querying
 - new method on node: .replace() to replace in place a node
-  https://redbaron.readthedocs.org/en/latest/other.html#replace
-- .map .filter and .apply are now documented https://redbaron.readthedocs.org/en/latest/other.html#map-filter-apply
+  https://redbaron.readthedocs.io/en/latest/other.html#replace
+- .map .filter and .apply are now documented https://redbaron.readthedocs.io/en/latest/other.html#map-filter-apply
 - .edit() new helper method to launch a text editor on the selected node and
-  replace the node with the modified code https://redbaron.readthedocs.org/en/latest/other.html#edit
+  replace the node with the modified code https://redbaron.readthedocs.io/en/latest/other.html#edit
 - .root node attribute (property) that return the root node of the tree in which the
-  node is stored https://redbaron.readthedocs.org/en/latest/other.html#root
+  node is stored https://redbaron.readthedocs.io/en/latest/other.html#root
 - .index node attribute (property) that returns the index at which the node is
-  store if it's store in a nodelist, None otherwise https://redbaron.readthedocs.org/en/latest/other.html#index
+  store if it's store in a nodelist, None otherwise https://redbaron.readthedocs.io/en/latest/other.html#index
 - setitem (a[x] = b) on nodelist now works as expected (accepting string, fst
   node and redbaron node)
-- new method to handle indentation: .increase_indentation and .decrease_indentation https://redbaron.readthedocs.org/en/latest/other.html#increase-indentation-and-decrease-indentation
+- new method to handle indentation: .increase_indentation and .decrease_indentation https://redbaron.readthedocs.io/en/latest/other.html#increase-indentation-and-decrease-indentation
 - various small bugfix
 - we have one new contributor \o/ https://github.com/ze42
 - to_node has been move to a class method of Node: Node.from_fst


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.