### PR TITLE
[doc] fix typos

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,7 +35,7 @@ will be for other releases, the workload is already big enough.
 
 - BIG improvement on the proxy list merging algorithm, it is not perfect yet (comments aren't handled yet) but it's really a big move forward
 - possible retrocompatibility breaking change: from now on the node.find("name") to node.name shortcut ONLY works with possible nodes identifiers. For example node.i_dont_exist_as_an_identifier will raise AttributeError
-- new helper method .to_python that wrap ast.literal_eval on compatibile nodes https://redbaron.readthedocs.io/en/latest/other.html#to-python
+- new helper method .to_python that wrap ast.literal_eval on compatible nodes https://redbaron.readthedocs.io/en/latest/other.html#to-python
 - breaking: IntNode no longer return an int on .value but a .string instead, use .to_python to have an evaluated version
 - fix node.decrease_indentation (that was simply not working)
 - fix code_block_node.value was broken on node with no parent
@@ -49,7 +49,7 @@ will be for other releases, the workload is already big enough.
 - new helper methods: .next_recursive and .previous_recursive https://redbaron.readthedocs.io/en/latest/other.html
 - fix: doc is tested in CI now, it shouldn't break anymore
 - more rendering test for python3, it shouldn't break anymore
-- pygments is now an optional dependancy, "pip install redbaron" won't install it, "pip install redbaron[pygments"] will
+- pygments is now an optional dependency, "pip install redbaron" won't install it, "pip install redbaron[pygments"] will
 - new node.next_intuitive and node.previous_intuitive methods for situations where .next/previous doesn't behave the way the user expect it https://redbaron.readthedocs.io/en/latest/other.html#next-intuitive-previous-intuitive
 
 0.5.1 (2015-03-11)
@@ -69,7 +69,7 @@ will be for other releases, the workload is already big enough.
   behavior should be way more stable and never crash.
 - new helpers .names, .modules, .full_path_modules for from_import node https://redbaron.readthedocs.io/en/latest/other.html#index-on-parent-raw
 - add a node.index_on_parent_raw and make node.index_on_parent works has it
-  should be intuitivly according to the proxy list api https://redbaron.readthedocs.io/en/latest/other.html#index-on-parent-raw
+  should be intuitively according to the proxy list api https://redbaron.readthedocs.io/en/latest/other.html#index-on-parent-raw
 - new helper methods: .insert_before and .insert_after https://redbaron.readthedocs.io/en/latest/other.html#insert-before-insert-after
 - fix: some white space bugs in the merging algorithm of line proxy
 - fix: on_attribute and parent were correctly set on newly added elements to

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ RedBaron is a python library and tool powerful enough to be used into IPython
 solely that intent to make the process of **writing code that modify source
 code** as easy and as simple as possible. That include writing custom
 refactoring, generic refactoring, tools, IDE or directly modifying you source
-code into IPython with an higher and more powerful abstraction than the
+code into IPython with a higher and more powerful abstraction than the
 advanced texts modification tools that you find in advanced text editors and
 IDE.
 
@@ -15,7 +15,7 @@ RedBaron guaranteed you that **it will only modify your code where you ask him
 to**. To achieve this, it is based on [Baron](https://github.com/PyCQA/baron)
 a lossless [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) for
 Python that guarantees the operation <code>ast_to_code(code_to_ast(source_code)) == source_code</code>.
-(Baron's AST is called a FST, a Full Syntax Tree).
+(Baron's AST is called an FST, a Full Syntax Tree).
 
 RedBaron API and feel is heavily inspired by BeautifulSoup. It tries to be
 simple and intuitive and that once you've get the basics principles, you are
@@ -32,7 +32,7 @@ There might be the only exception that if you directly call specific nodes
 constructors with FST that this API change, but this is not documented and
 simply horribly unpracticable, so I'm expecting no one to do that.
 
-**Disclamer**: RedBaron (and baron) is **working** with python3 but it NOT fully parsing it yet.
+**Disclaimer**: RedBaron (and baron) is **working** with python3 but it is NOT fully parsing it yet.
 
 Installation
 ============
@@ -62,7 +62,7 @@ As a member of [PyCQA](https://github.com/PyCQA), RedBaron follows its [Code of 
 Links
 =====
 
-**RedBaron is fully documented, be sure to check the turorial and documentation**.
+**RedBaron is fully documented, be sure to check the tutorial and documentation**.
 
 * [Tutorial](https://redbaron.readthedocs.io/en/latest/tuto.html)
 * [Documentation](https://redbaron.readthedocs.io/en/latest/)

--- a/TODO.md
+++ b/TODO.md
@@ -55,7 +55,7 @@ It should be easy to wrap statement, expressions or various structure in other
 statements, like a statement with a block or an associative parenthesis or
 those kind of things.
 
-### Magic convertion on setattr
+### Magic conversion on setattr
 
 Comment: I'm not that much sure that I'll do those one, .replace already quite handle this job.
 

--- a/docs/dotproxylist.rst
+++ b/docs/dotproxylist.rst
@@ -17,7 +17,7 @@ DotProxyList usage examples
     red = RedBaron("a.b(c).d[e]")
 
 Please refer to `python list documentation
-<https://docs.python.org/2/tutorial/datastructures.html>`_ a if you want to
+<https://docs.python.org/2/tutorial/datastructures.html>`_ if you want to
 know the exact behavior or those methods (or `send a patch
 <https://github.com/PyCQA/redbaron>`_ to improve this documentation).
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,10 +5,10 @@ Introduction
 ------------
 
 RedBaron is a python library and tool powerful enough to be used into IPython
-solely that intent to make the process of **writting code that modify source
+solely that intent to make the process of **writing code that modify source
 code** as easy and as simple as possible. That include writing custom
 refactoring, generic refactoring, tools, IDE or directly modifying you source
-code into IPython with an higher and more powerful abstraction than the
+code into IPython with a higher and more powerful abstraction than the
 advanced texts modification tools that you find in advanced text editors and
 IDE.
 
@@ -75,7 +75,7 @@ Though to be used in IPython directly:
 .. ipython:: python
 
     red  # direct feedback like BeautifulSoup, "0" here is the index of the node in our source code
-    red.help()  # helper function that discribe nodes content so you don't have to read the doc
+    red.help()  # helper function that describe nodes content so you don't have to read the doc
 
 
 Easy nodes modifications, you already know how to code in python, so pass

--- a/docs/lineproxylist.rst
+++ b/docs/lineproxylist.rst
@@ -17,7 +17,7 @@ LineProxyList usage examples
     red = RedBaron("def a():\n    pif\n\n    paf\n    pouf\n")
 
 Please refer to `python list documentation
-<https://docs.python.org/2/tutorial/datastructures.html>`_ a if you want to
+<https://docs.python.org/2/tutorial/datastructures.html>`_ if you want to
 know the exact behavior or those methods (or `send a patch
 <https://github.com/PyCQA/redbaron>`_ to improve this documentation).
 

--- a/docs/nodes_reference.rst
+++ b/docs/nodes_reference.rst
@@ -205,7 +205,7 @@ The node represents a binary number value.
 BinaryOperatorNode
 ==================
 
-The node represents a binary operator (an operator (e.g: :file:`+` :file:`-` :file:`/`..) applied to 2 values) with its operands. For e.g.: :file:`1 + 1`.
+The node represents a binary operator (an operator (e.g.: :file:`+` :file:`-` :file:`/`..) applied to 2 values) with its operands. For e.g.: :file:`1 + 1`.
 
 .. ipython:: python
 
@@ -229,7 +229,7 @@ SetAttr
 BooleanOperatorNode
 ===================
 
-The node represents a boolean operator (an operator (e.g: :file:`and` :file:`or`) applied to 2 values) with its operands. For e.g.: :file:`x and y`.
+The node represents a boolean operator (an operator (e.g.: :file:`and` :file:`or`) applied to 2 values) with its operands. For e.g.: :file:`x and y`.
 
 .. ipython:: python
 
@@ -658,7 +658,7 @@ work as expected:
 ExecNode
 ========
 
-A node representing a exec statement.
+A node representing an exec statement.
 
 .. ipython:: python
 

--- a/docs/other.rst
+++ b/docs/other.rst
@@ -150,7 +150,7 @@ have been introduced:
     red.try_.next_intuitive.next_intuitive
 
 This also applies to :file:`IfNode`, :file:`ElifNode`, :file:`ElseNode`,
-:file:`ForNode` and :file:`WhileNode` (both of the last one can have a else
+:file:`ForNode` and :file:`WhileNode` (both of the last one can have an else
 statement). This also works coming from nodes outsides of those previous nodes.
 
 For :file:`IfNode`, :file:`ElifNode` and :file:`ElseNode` **inside** an
@@ -170,13 +170,13 @@ For :file:`IfNode`, :file:`ElifNode` and :file:`ElseNode` **inside** an
 
 .. warning::
 
-    There is a subtility: :file:`IfelseblockNode` is **unaffected** by this
+    There is a subtlety: :file:`IfelseblockNode` is **unaffected** by this
     behavior: you have to use :file:`next_intuitive` or
     :file:`previous_intuitive` on :file:`IfNode`, :file:`ElifNode` and
     :file:`ElseNode` **inside** IfelseblockNode.
 
     But, if you do a :file:`next_intuitive` or :file:`previous_intuitive` or a
-    node arround :file:`IfelseblockNode` it will jump to the first or last node
+    node around :file:`IfelseblockNode` it will jump to the first or last node
     **inside** the :file:`IfelseblockNode`.
 
     See this example
@@ -275,7 +275,7 @@ node, space node or endl node).
     red[0].value.filtered()
 
 Note: the fact that it's a tuple that is returned will probably evolve in the
-futur into a node list proxy or something like that, I just don't have the time
+future into a node list proxy or something like that, I just don't have the time
 to do something better right now.
 
 .indentation
@@ -367,7 +367,7 @@ RedBaron provides a Path class that represent a path to a node.
 .map .filter .apply
 -------------------
 
-RedBaron nodes list have 3 helper methods :file:`.map`, :file:`.filter` and :file:`.apply` quite similar to python buildins (except for apply). The main difference is that they return a node list instance instead of a python buildin list.
+RedBaron nodes list have 3 helper methods :file:`.map`, :file:`.filter` and :file:`.apply` quite similar to python builtins (except for apply). The main difference is that they return a node list instance instead of a python buildin list.
 
 * :file:`.map` takes a callable (like a lambda or a function) that receive a
   node as first argument, this callable is applied on every node of the node
@@ -425,7 +425,7 @@ editor. The result is parsed and replace the code of the current node.
     # red.return_.edit()
 
 By default, the editor is taken from the variable :file:`EDITOR` in the
-environements variables. If this variable is not present, nano is used. You can
+environment variables. If this variable is not present, nano is used. You can
 use a different editor this way: :file:`node.edit(editor="vim")`.
 
 .absolute_bounding_box
@@ -456,7 +456,7 @@ argument since the left parenthesis is not a redbaron Node.
 
 Every node has the :file:`bounding_box` property which holds the
 top-left and bottom-right position of the node. Compared to the
-:file:`absolute_bounding_box` property, it assumes the the node is the
+:file:`absolute_bounding_box` property, it assumes the node is the
 root node so the top-left position is always :file:`(1, 1)`.
 
 .. ipython:: python
@@ -492,7 +492,7 @@ Returns first node at specific line
 Node.from_fst()
 ---------------
 
-:file:`Node.from_fst()` is an helper class method that takes a FST node and return a
+:file:`Node.from_fst()` is a helper class method that takes an FST node and return a
 RedBaron node instance. Except if you need to go down at a low level or that
 RedBaron doesn't provide the helper you need, you shouldn't use it.
 
@@ -516,8 +516,8 @@ parameters.
 NodeList.from_fst()
 -------------------
 
-Similarly to :file:`Node.from_fst()`, :file:`NodeList.from_fst()` is an helper
-class method that takes a FST node **list** and return a RedBaron node **list**
+Similarly to :file:`Node.from_fst()`, :file:`NodeList.from_fst()` is a helper
+class method that takes an FST node **list** and return a RedBaron node **list**
 instance. Similarly, you probably don't need to go so low level.
 
 

--- a/docs/proxy_list.rst
+++ b/docs/proxy_list.rst
@@ -32,7 +32,7 @@ a list, you need to take care of a lot of details:
 * also, what to do if the list is declared in an indented way (with :file:`"\\n    "` after every comma for example)?
 * etc...
 
-And that's only for acomma separated list of things: you also have the
+And that's only for a comma separated list of things: you also have the
 same formatting details to care about for dot separated lists
 (e.g. :file:`a.b.c().d[plop]`) and endl separated lists (a python code block,
 or you whole source file).
@@ -69,7 +69,7 @@ There are, for now, 4 kind of proxy lists:
 * :file:`DecoratorLineProxyList` which handles lists of decorators (they are nearly the
   same as :file:`LineProxyList`)
 
-**Be aware that the proxy list are setted on the attribute that is a list, not
+**Be aware that the proxy list are set on the attribute that is a list, not
 on the node holding the list. See the 'value' attribute access in the
 examples below.**
 
@@ -80,7 +80,7 @@ As said, proxy lists have the exact same API than python lists (at the exception
 that they don't implement the :file:`sort` and :file:`reverse` methods).
 Every method accepts as input the same inputs that you can use to modify a node
 in RedBaron. This means that you can pass a string containing source code,
-a FST or a RedBaron node.
+an FST or a RedBaron node.
 
 Here is a session demonstrating every method of a proxy list:
 

--- a/docs/querying.rst
+++ b/docs/querying.rst
@@ -128,7 +128,7 @@ compiled regex:
     red.find(re.compile("^n"))
     red.find_all(re.compile("^n"))
 
-Having to compile regex is boring, so you can use this shorthand syntaxe
+Having to compile regex is boring, so you can use this shorthand syntax
 instead (prefixing a string with "re:"):
 
 .. ipython:: python
@@ -179,7 +179,7 @@ the member of the list/tuple:
 \*args and default value
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can also pass as namy callable as args (without giving it a key) as you
+You can also pass as many callable as args (without giving it a key) as you
 want, those callables will receive the node itself as first argument (and must
 return a value that will be tested as a boolable):
 

--- a/docs/tuto.rst
+++ b/docs/tuto.rst
@@ -297,7 +297,7 @@ represents a whole valid python program (so for example: :file:`.replace("*args,
 
 This is generally very useful when working on queries. For example (a real life
 example), here is the code to replace every :file:`print stuff` (prints
-statement of **one** argument, an example with multiple arguments is left as an exercice to the
+statement of **one** argument, an example with multiple arguments is left as an exercise to the
 reader) with :file:`logger.debug(stuff)`:
 
 ::
@@ -397,7 +397,7 @@ Misc things
 A short list of useful features of RedBaron:
 
 * :file:`.map`, a method of RedBaron lists that takes a callable (like a lambda or a function), apply it to every one of its members and returns a RedBaron list containing the result of the call
-* :file:`.apply` same than :file:`.map` except it returns a RedBaron list of the nodes on which the callable has been applied (i.e. the members before the call instead of the members after the call) (for simplicity we uses the :file:`int` buildin function here, you might want to look at :file:`to_python` in the futur for a more generic convertion operation)
+* :file:`.apply` same than :file:`.map` except it returns a RedBaron list of the nodes on which the callable has been applied (i.e. the members before the call instead of the members after the call) (for simplicity we uses the :file:`int` builtin function here, you might want to look at :file:`to_python` in the future for a more generic conversion operation)
 
 .. ipython:: python
 

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -1,7 +1,7 @@
 Why is this important?
 ======================
 
-The usage of a FST might not be obvious at first sight so let's consider a
+The usage of an FST might not be obvious at first sight so let's consider a
 series of problems to illustrate it. Let's say that you want to write a program that will:
 
 * rename a variable in a source file... without clashing with things that are not a variable (example: stuff inside a string)
@@ -14,7 +14,7 @@ series of problems to illustrate it. Let's say that you want to write a program 
 * implement the class browser of smalltalk for python (the whole one where you can edit the code of the methods, not just showing code)
 
 It is very likely that you will end up with the awkward feeling of writing
-clumpsy weak code that is very likely to break because you didn't thought about
+clumsy weak code that is very likely to break because you didn't thought about
 all the annoying special cases and the formatting keeps bothering you. You may
 end up playing with `ast.py <http://docs.python.org/2/library/ast.html>`_ until
 you realize that it removes too much information to be suitable for those
@@ -36,7 +36,7 @@ complex task).
 Other usages
 ------------
 
-Having a FST (or at least a good abstraction build on it) also makes it easier
+Having an FST (or at least a good abstraction build on it) also makes it easier
 to do code generation and code analysis while those two operations are already
 quite feasible (using `ast.py <http://docs.python.org/2/library/ast.html>`_ and 
 a templating engine for example).


### PR DESCRIPTION
Found mostly using [mwic](http://jwilk.net/software/mwic) and [anorack](https://github.com/jwilk/anorack).