### PR TITLE
Fix indentation when inserting multiple indented lines

### DIFF
--- a/redbaron/base_nodes.py
+++ b/redbaron/base_nodes.py
@@ -1789,7 +1789,7 @@ class LineProxyList(ProxyList):
             expected_list.append(i[0])
             log("-- current result: %s", ["".join(map(lambda x: x.dumps(), expected_list))])
 
-            if previous and previous.type == "endl" and i[0].type != "endl" and previous.indentation != indentation:
+            if previous and previous.type == "endl" and i[0].type != "endl" and previous.indent != indentation:
                 log("Previous is endl and current isn't endl and identation isn't correct, fix it")
                 previous.indent = indentation
 


### PR DESCRIPTION
Fix indentation when inserting multiple indented lines, per
https://github.com/PyCQA/redbaron/issues/151

It is clear from stepping through the code in this scenario that the intent of the original author was to refer to previous.indent, not previous.indentation. c.f. two lines later where the two are assigned. 