### PR TITLE
Add insert_multiple() method to accelerate insertion of multiple lines

### DIFF
--- a/redbaron/base_nodes.py
+++ b/redbaron/base_nodes.py
@@ -1418,6 +1418,17 @@ class ProxyList(object):
         self.data.insert(index, [value, None])
         self._synchronise()
 
+    # sdh4 11/14/17 add insert_multiple
+    def insert_multiple(self,index,values):
+        """ Insert multiple values from an iterable into the ProxyList 
+        at the specified index, without resynchronizing after each one. """
+        for value in values:
+            value = self._convert_input_to_node_object(value, parent=self.node_list, on_attribute=self.on_attribute)
+            self.data.insert(index, [value, None])
+            index+=1
+            pass
+        self._synchronise()
+    
     def append(self, value):
         self.insert(len(self), value)
 


### PR DESCRIPTION
Per https://github.com/PyCQA/redbaron/issues/149  accelerate inserting multiple lines at one time by only calling _synchronize() once.  This patch adds a new method for inserting multiple lines in one steip, dramatically accelerating the insertion process