### PR TITLE
Use new method to avoid pypandoc warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@
 from setuptools import setup
 
 try:
-    from pypandoc import convert
-    read_md = lambda f: convert(f, 'rst')
+    from pypandoc import convert_file
+    read_md = lambda f: convert_file(f, 'rst')
 except ImportError:
     print("warning: pypandoc module not found, could not convert Markdown to RST")
     read_md = lambda f: open(f, 'r').read()


### PR DESCRIPTION
This fixes the following deprecation warning:
```
setup.py:8: DeprecationWarning: Due to possible ambiguity, 'convert()' is deprecated. Use 'convert_file()'  or 'convert_text()'.
  read_md = lambda f: convert(f, 'rst')
```