### PR TITLE
Fix tests under pytest 4

### DIFF
--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -8,13 +8,17 @@ import pytest
 from redbaron import RedBaron
 
 
-@pytest.fixture
 def red():
     return RedBaron("""\
 @deco
 def a(c, d):
     b = c + d
 """)
+
+
+@pytest.fixture(name="red")
+def red_fixture():
+    return red()
 
 
 fst = red()


### PR DESCRIPTION
Pytest 4 removed support for calling fixtures directly: https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly

This leads to an error when trying to run the tests:
```
==================================== ERRORS ====================================
_________________ ERROR collecting tests/test_bounding_box.py __________________
Fixture "red" called directly. Fixtures are not meant to be called directly,
but are created automatically when test functions request them as parameters.
See https://docs.pytest.org/en/latest/fixture.html for more information about fixtures, and
https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly about how to update your code.
```