### PR TITLE
Fix CI by pinning pytest requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 install:
-  - pip install git+https://github.com/Psycojoker/baron.git
-  - pip install pytest
+  - pip install -r requirements.txt
   - find . -name '*.pyc' -delete
   - python setup.py install
 python:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 baron
-pytest
+pytest<4
+more-itertools<8
 pygments


### PR DESCRIPTION
#179 seems stale. Tests can be made to pass by downgrading `pytest`, so do that until #179 can be resurrected.