### PR TITLE
DOC: Fix link syntax to use RST way.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -127,12 +127,12 @@ Financial support
 
 Baron and RedBaron are a very advanced piece of engineering that requires a lot
 of time of concentration to work on. Until the end of 2018, the development
-has been a full volunteer work mostly done by [Bram](https://github.com/psycojoker),
+has been a full volunteer work mostly done by `Bram <https://github.com/psycojoker>`_,
 but now, to reach the next level and bring those projects to the stability and
 quality you expect, we need your support.
 
 You can join our contributors and sponsors on our transparent
-[OpenCollective](https://opencollective.com/redbaron), every contribution will
+`OpenCollective <https://opencollective.com/redbaron>`_, every contribution will
 count and will be mainly used to work on the projects stability and quality but
 also on continuing, on the side, the R&D side of those projects.
 


### PR DESCRIPTION
Markdown way is not understood by default unless you use an extension like MySt (https://myst-parser.readthedocs.io/)